### PR TITLE
Fix bug where space still contained piece

### DIFF
--- a/lib/Games/Board/Piece.pm
+++ b/lib/Games/Board/Piece.pm
@@ -105,19 +105,21 @@ C<$space> is a Games::Board::Space object, the piece is moved to that space.
 sub move {
   my $piece = shift;
   my ($how, $which) = @_;
-  my $space;
+  my $new_space;
+  my $old_space = $piece->current_space;
 
   if ($how eq 'dir') {
-    return unless $piece->current_space;
-    return unless $space = $piece->current_space->dir($which);
+    return unless $old_space;
+    return unless $new_space = $old_space->dir($which);
   } elsif ($how eq 'to') {
     return unless eval { $which->isa('Games::Board::Space') };
-    $space = $which;
+    $new_space = $which;
   } else {
     return;
   }
 
-  $space->receive($piece);
+  return unless !$old_space || $old_space->take($piece);
+  $new_space->receive($piece);
 }
 
 1;

--- a/lib/Games/Board/Space.pm
+++ b/lib/Games/Board/Space.pm
@@ -132,4 +132,22 @@ sub receive {
   push @{$self->{contents}}, $piece->id;
 }
 
+=method take
+
+  $space->take($piece);
+
+This method removes the piece from this space.
+
+=cut
+
+sub take {
+  my ($self, $piece) = @_;
+
+  return unless eval { $piece->isa('Games::Board::Piece') };
+  return unless $self->contains($piece);
+
+  delete $piece->{current_space};
+  $self->{contents} = [ grep { $_ ne $piece->id } @{$self->{contents}} ];
+}
+
 1;

--- a/t/chess-custom.t
+++ b/t/chess-custom.t
@@ -74,3 +74,5 @@ $rook->move(to => $board->space('b2'));
 is($rook->current_space_id, 'b2', "rook is at b2");
 $rook->move(dir => [2,1]);
 is($rook->current_space_id, 'd3', "rook is at d3");
+
+ok(!$board->space('b2')->contains($rook), "space b2 does not contain rook");


### PR DESCRIPTION
Came across this niffy little module, I'm using it for one of my projects (https://github.com/jgoodman/Artemis). Anyway, I noticed a bug where if you move a game piece, it would still be listed in the Game::Board::Piece object's contain. Thought I would fix that. Let me know if this works or if there is anything you want me to change.